### PR TITLE
[OT267-40] - Setup Amazon S3 SDK

### DIFF
--- a/helpers/s3Client.js
+++ b/helpers/s3Client.js
@@ -1,0 +1,10 @@
+const S3 = require('aws-sdk/clients/s3');
+const accessKeyId = process.env.aws_access_key_id;
+const secretAccessKey = process.env.aws_secret_access_key;
+
+const s3Client = new S3({
+  accessKeyId,
+  secretAccessKey,
+});
+
+module.exports = { s3Client };

--- a/helpers/s3Client.js
+++ b/helpers/s3Client.js
@@ -1,4 +1,5 @@
 const S3 = require('aws-sdk/clients/s3');
+
 const accessKeyId = process.env.aws_access_key_id;
 const secretAccessKey = process.env.aws_secret_access_key;
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@sendgrid/mail": "^7.7.0",
+    "aws-sdk": "~2.1205.0",
     "bcrypt": "^5.0.1",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",


### PR DESCRIPTION
Se creo el archivo s3Client.js en la carpeta de helpers para generar el setup de la conexión a los servicios de s3 (Simple Storage Services) de Amazon Web Services, la cual posteriormente se utilizarpa para guardar archivos como imagenes. Se usaron las credenciales suministradas.

Url: https://alkemy-labs.atlassian.net/jira/software/c/projects/OT267/boards/362?modal=detail&selectedIssue=OT267-40&assignee=6134df22c425a20068de3c0e