### PR TITLE
[OT267-70]-Endpoint-create-testimony

### DIFF
--- a/controllers/testimonials.js
+++ b/controllers/testimonials.js
@@ -3,7 +3,24 @@
 const { success, error, serverError } = require('../helpers/requestResponses');
 
 const getAllTestimonials = async (req, res) => { success({ res, message: 'all testimonials' }); };
+const { createTestimony } = require('../services/testimony');
 
-module.exports = { getAllTestimonials };
+const createATestimony = async (req, res) => {
+  const { name, content } = req.body;
+
+  try {
+    const newTestimony = await createTestimony(name, content);
+
+    if (!newTestimony) return error({ res, message: 'Testimony already exists', status: 400 });
+
+    return success({
+      res, message: 'Testimony created', status: 201, data: newTestimony,
+    });
+  } catch (err) {
+    return serverError({ res, message: err.message });
+  }
+};
+
+module.exports = { getAllTestimonials, createATestimony };
 
 // ESLINT TEMPORAL

--- a/migrations/20220822155055-create-testimony.js
+++ b/migrations/20220822155055-create-testimony.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable('Testimonials', {
+    await queryInterface.createTable('Testimonies', {
       id: {
         allowNull: false,
         autoIncrement: true,
@@ -33,6 +33,6 @@ module.exports = {
     });
   },
   async down(queryInterface, Sequelize) {
-    await queryInterface.dropTable('Testimonials');
+    await queryInterface.dropTable('Testimonies');
   },
 };

--- a/routes/testimonials.js
+++ b/routes/testimonials.js
@@ -1,9 +1,13 @@
 const express = require('express');
 
-const { getAllTestimonials } = require('../controllers/testimonials');
+const { getAllTestimonials, createATestimony } = require('../controllers/testimonials');
+const { validateCreateTestimony } = require('../validators/validateTestimony');
+const { isAuth } = require('../middlewares/isAuth');
+const { isAdmin } = require('../middlewares/isAdmin');
 
 const router = express.Router();
 
 router.get('/', getAllTestimonials);
+router.post('/', [isAuth, isAdmin, validateCreateTestimony], createATestimony);
 
 module.exports = router;

--- a/seeders/20220822155616-demo-testimony.js
+++ b/seeders/20220822155616-demo-testimony.js
@@ -3,13 +3,12 @@
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.bulkInsert(
-      'Testimonials',
+      'Testimonies',
       [
         {
           name: 'Mi primer testimonio',
           image: 'ejemplo.jpg',
-          content:
-                        'Mi experiencia con Somos Mas es altamente positiva.',
+          content: 'Mi experiencia con Somos Mas es altamente positiva.',
           createdAt: new Date(),
           updatedAt: new Date(),
         },
@@ -19,6 +18,6 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.bulkDelete('Testimonials', null, {});
+    await queryInterface.bulkDelete('Testimonies', null, {});
   },
 };

--- a/services/testimony.js
+++ b/services/testimony.js
@@ -1,0 +1,17 @@
+const { Testimony } = require('../models/index');
+
+const createTestimony = async (name, content) => {
+  const [testimony, created] = await Testimony.findOrCreate({
+    where: {
+      name: name.toLowerCase(),
+      content,
+    },
+  });
+
+  if (created) return testimony;
+  return created;
+};
+
+module.exports = {
+  createTestimony,
+};

--- a/validators/validateTestimony.js
+++ b/validators/validateTestimony.js
@@ -1,0 +1,27 @@
+const { check } = require('express-validator');
+
+const { handleResult } = require('../middlewares/validateFields');
+
+const validateCreateTestimony = [
+  check('name', 'Ingrese un nombre para el testimonio')
+    .isString()
+    .isLength({ min: 6 })
+    .withMessage('El nombre es muy corto, pruebe con otro')
+    .trim()
+    .escape(),
+
+  check('content', 'Ingrese un contenido para el testimonio')
+    .isString()
+    .isLength({ min: 100 })
+    .withMessage('El contenido debe ser de un minimo de 100 caracteres')
+    .trim()
+    .escape(),
+
+  (req, res, next) => {
+    handleResult(req, res, next);
+  },
+];
+
+module.exports = {
+  validateCreateTestimony,
+};


### PR DESCRIPTION
<h2>Task<h2>

[Card. Endpoint para creacion de testimonio](https://alkemy-labs.atlassian.net/jira/software/c/projects/OT267/boards/362?modal=detail&selectedIssue=OT267-70)

<h2>Actions<h2>

- Created the endpoint and the service to create a new Testimony
- Only admins can access
- Fields are validated
- Fixed the model, seeder, and migrate (problems with the names)

<h2>Snips<h2>
<h4>Success request<h4>
<img width="776" alt="Create testimony success" src="https://user-images.githubusercontent.com/80550062/187959741-3d115d46-51d0-4898-a335-9d5931408c7d.png">

<h4>Fields validate<h4>
<img width="776" alt="Create testimony fields error" src="https://user-images.githubusercontent.com/80550062/187959928-669bf6c6-90e9-4ad3-ae14-a9b5e32cea77.png">

<h4>Testimony already exists<h4>
<img width="773" alt="testimony already exists" src="https://user-images.githubusercontent.com/80550062/187959959-0df899a9-e34a-4961-83b7-981b96ee6a3e.png">
