### PR TITLE
[OT267-88] Agregar paginación a Miembros

### DIFF
--- a/controllers/members.js
+++ b/controllers/members.js
@@ -1,7 +1,9 @@
 const { success, error, serverError } = require('../helpers');
+const { paginator } = require('../helpers/paginator');
+const { Member } = require('../models/index');
 const {
   createMember,
-  findAllMembers,
+  // findAllMembers,
   deleteMember,
 } = require('../services/members');
 
@@ -30,9 +32,10 @@ const createNewMember = async (req, res) => {
   }
 };
 
-const getAllMembers = async (_req, res) => {
+const getAllMembers = async (req, res) => {
   try {
-    const data = await findAllMembers();
+    // const data = await findAllMembers();
+    const data = await paginator(req, Member, 'news');
 
     if (data.length === 0) return error({ res, message: 'no members' });
 

--- a/helpers/paginator.js
+++ b/helpers/paginator.js
@@ -1,0 +1,53 @@
+const paginator = async (req, model, urlmodel) => {
+  // endpoint
+  const url = `http://localhost:3000/${urlmodel}?page=`;
+
+  // pages
+  const getNextPage = (page, limit, total) => {
+    if ((total / limit) > page) {
+      return url + (page + 1);
+    }
+    return null;
+  };
+
+  const getPreviousPage = (page, limit, total) => {
+    if ((total / limit) < page) return url + 1;
+    if (page <= 1) return null;
+    return url + (page - 1);
+  };
+
+  // getOffset
+  const getOffset = (page, limit) => (page * limit) - limit;
+
+  // current page
+  let page = 1;
+  if (!Number.isNaN(Number(req.query.page))) { page = Number(req.query.page); }
+
+  // rows per pagina
+  const limit = 10;
+
+  // request
+  const options = {
+    offset: getOffset(page, limit),
+    limit,
+  };
+
+  const { count, rows } = await model.findAndCountAll(options);
+
+  // total pages
+  const totalPages = Math.ceil(count / limit);
+
+  return {
+    totalPages,
+    previousPage: getPreviousPage(page, limit, count),
+    currentPage: page > totalPages ? 'page does not exist' : page,
+    nextPage: getNextPage(page, limit, count),
+    totalRows: count,
+    rowsPerPage: limit,
+    rows,
+  };
+};
+
+module.exports = {
+  paginator,
+};


### PR DESCRIPTION
Endpoint get /members; trae el listado de miembros paginado. 
Recibe "page" por query
![image](https://user-images.githubusercontent.com/88160324/189529562-a3f8e932-9d79-4949-9ac5-dabb9c79c67b.png)

