### PR TITLE
[OT267-86] Agregar paginación a Categorías

### DIFF
--- a/controllers/categories.js
+++ b/controllers/categories.js
@@ -1,11 +1,13 @@
-const { success, error, serverError } = require('../helpers');
+const {
+  success, error, serverError, paginator,
+} = require('../helpers');
 const {
   deleteCategory,
-  allCategoriesName,
   updateCategoryByPk,
   findCategoryById,
   createCategory,
 } = require('../services/category');
+const { Category } = require('../models');
 
 const createNewCategory = async (req, res) => {
   try {
@@ -49,7 +51,7 @@ const deleteSingleCategory = async (req, res) => {
 
 const getAllCategoriesName = async (req, res) => {
   try {
-    const categoriesName = await allCategoriesName();
+    const categoriesName = await paginator(req, Category, 'categories', { attributes: ['id', 'name'] });
     success({
       res,
       message: 'list of the name of all categories',

--- a/helpers/paginator.js
+++ b/helpers/paginator.js
@@ -11,7 +11,9 @@ const paginator = async (req, model, urlmodel, moreOptions) => {
   };
 
   const getPreviousPage = (page, limit, total) => {
-    if ((total / limit) < page) return url + 1;
+    const maxPages = Math.ceil(total / limit);
+
+    if (maxPages < page) return url + maxPages;
     if (page <= 1) return null;
     return url + (page - 1);
   };
@@ -32,6 +34,7 @@ const paginator = async (req, model, urlmodel, moreOptions) => {
     limit,
     ...moreOptions,
   };
+  console.log(options);
 
   const { count, rows } = await model.findAndCountAll(options);
 

--- a/helpers/paginator.js
+++ b/helpers/paginator.js
@@ -34,7 +34,6 @@ const paginator = async (req, model, urlmodel, moreOptions) => {
     limit,
     ...moreOptions,
   };
-  console.log(options);
 
   const { count, rows } = await model.findAndCountAll(options);
 

--- a/helpers/paginator.js
+++ b/helpers/paginator.js
@@ -1,4 +1,4 @@
-const paginator = async (req, model, urlmodel) => {
+const paginator = async (req, model, urlmodel, moreOptions) => {
   // endpoint
   const url = `http://localhost:3000/${urlmodel}?page=`;
 
@@ -30,6 +30,7 @@ const paginator = async (req, model, urlmodel) => {
   const options = {
     offset: getOffset(page, limit),
     limit,
+    ...moreOptions,
   };
 
   const { count, rows } = await model.findAndCountAll(options);


### PR DESCRIPTION
## Tarea: https://alkemy-labs.atlassian.net/browse/OT267-86

## Actions:
✅ Feat: add pagination in categories
:octocat: fix: previous page error in paginator

##
<p> En las peticiones se puede observar las respuestas paginadas con máximo 10 objetos por pagina </p>

## Snips:

### GET /categories - primer pagina

![categorias primer pagina](https://user-images.githubusercontent.com/89743809/189735538-15b6b375-b7b4-46db-8260-b6da22ecb4ed.PNG)

##
### GET /categories - ultima pagina

![ultima pagina categories](https://user-images.githubusercontent.com/89743809/189744612-a4af073f-a7e9-40c1-bd10-e15d64408cc6.PNG)

##
### GET /categories - pagina inexistente

![pagina inexistente categorias](https://user-images.githubusercontent.com/89743809/189745013-bca3e4be-d85d-4aba-a050-ce587a587f05.PNG)

##
Mentor: @FerLeiva 

