### PR TITLE
Ot267 post news swagger

### DIFF
--- a/routes/news.js
+++ b/routes/news.js
@@ -415,7 +415,7 @@ router.get('/:id', isAuth, isAdmin, validateId, getSingleNews);
  *    requestBody:
  *      required: true
  *      content:
- *        application/json:
+ *        multipart/form-data:
  *          schema:
  *            type: object
  *            $ref: '#/components/schemas/News'

--- a/routes/news.js
+++ b/routes/news.js
@@ -64,6 +64,7 @@ const {
  *          description: news content
  *        image:
  *          type: string
+ *          format: binary
  *          description: the news image
  *        type:
  *          type: string
@@ -364,7 +365,7 @@ router.get('/', isAuth, getAllNews);
  *    requestBody:
  *      required: true
  *      content:
- *        application/json:
+ *        multipart/form-data:
  *          schema:
  *            type: object
  *            $ref: '#/components/schemas/News'


### PR DESCRIPTION
Agregra opción para seleccionar arhivos en la documentación de Swagger en los endpoints de news para crear POST y actualizar PUT.